### PR TITLE
Combined hp and stat calculators

### DIFF
--- a/src/Core/PokemanzUtil.cs
+++ b/src/Core/PokemanzUtil.cs
@@ -8,6 +8,49 @@ namespace Pokemanz.Core
 {
     public static class PokemanzUtil
     {
+        //TODO: Pokemon stat calculator
+        //Stat Research is derived from: http://bulbapedia.bulbagarden.net/wiki/Statistic
+
+        //METHOD: PokemonStatCalc();
+        //Runs a stat calculation 5 times, once for each stat (attack, defence, spattack, spdefense, speed)
+        //Runs an Hp calculation 
+
+        //Needs to receive 
+        //--int dv from DvRandomizer()
+        //--Level of current pokemon
+        //--Base Stats from tab delimited for pokemon
+        //--Count of total Evs earned between last level up and new level up
+        //--New moves if any (NOT MVP)
+        //--Evolution (NOT MVP)
+        //If hits level 100, cannot level anymore (NOT MVP)
+
+        //QUESTIONS:
+        //--BaseStats found online seem too high and lack clarity. Are these stats assuming the pokemon is at level 1, 0, 100, or what? 
+        //--Is the stat calculation meant to add on to an existing stat, or replace it?
+        //--How do Exp points fit into this and what determines how much exp is needed per level?
+
+        //Dv randomizer is used in generating the pokemon's initial stats, as well as making levelling up produce diverse stats between two of the same pokemon at the same level.
+        //Dv reserach is derived from: http://bulbapedia.bulbagarden.net/wiki/Individual_values
+        /*static int DvRandomizer(int min, int max)
+        {
+            Random random = new Random();
+            int dv = random.Next(0, 15);
+            return dv;
+        }
+
+        public int CalcNewStat(int pokemon.basestat, int dv)
+        {
+            decimal newStat = ((((basestat + dv) * 2) + ((Math.Sqrt(Ev) / 4) * level) / 100) + 5;
+            //TODO: round down decimal newHp, and convert to int
+            return int newStat;
+        }
+
+        public int CalcNewHp(int pokemon.hp, int dv)
+        {
+            decimal newHp = ((((basestat + dv) * 2) + ((Math.Sqrt(Ev) / 4) * level) / 100) + level + 10;
+            //TODO: round down decimal newHp, and convert to int
+            return int newHp;
+        }*/
 
     }
 }

--- a/src/Core/PokemanzUtil.cs
+++ b/src/Core/PokemanzUtil.cs
@@ -31,26 +31,29 @@ namespace Pokemanz.Core
 
         //Dv randomizer is used in generating the pokemon's initial stats, as well as making levelling up produce diverse stats between two of the same pokemon at the same level.
         //Dv reserach is derived from: http://bulbapedia.bulbagarden.net/wiki/Individual_values
-        /*static int DvRandomizer(int min, int max)
+        static int DvRandomizer(int min, int max)
         {
             Random random = new Random();
-            int dv = random.Next(0, 15);
+            int dv = random.Next(0, 16);
             return dv;
         }
 
-        public int CalcNewStat(int pokemon.basestat, int dv)
+
+        //TODO: write method to loop through each stat type and assign a new value
+        public int LevelUpBaseStat(int pokemon.basestat, int dv)
         {
-            decimal newStat = ((((basestat + dv) * 2) + ((Math.Sqrt(Ev) / 4) * level) / 100) + 5;
-            //TODO: round down decimal newHp, and convert to int
-            return int newStat;
+            decimal newStat = ((((basestat + dv) * 2) + ((Math.Sqrt(Ev) / 4) * level) / 100) ;
+            if (pokemon.basestat == hp)
+            {
+                newStat += level + 10;
+            }
+            else
+            {
+                newStat += 5;
+            }
+            newStat = Math.Floor(newStat);
+            int levelUpBasestat = Decimal.ToInt32(newStat);
+            return levelUpBasestat;
         }
-
-        public int CalcNewHp(int pokemon.hp, int dv)
-        {
-            decimal newHp = ((((basestat + dv) * 2) + ((Math.Sqrt(Ev) / 4) * level) / 100) + level + 10;
-            //TODO: round down decimal newHp, and convert to int
-            return int newHp;
-        }*/
-
     }
 }

--- a/src/Core/Pokemon.cs
+++ b/src/Core/Pokemon.cs
@@ -21,6 +21,7 @@ namespace Pokemanz.Core
         public int SpAttack { get; set; }
         public int SpDefense { get; set; }
         public int Speed { get; set; }
+        public int Ev { get; set; }
     }
 
     public class PokemonPropertyAttribute : Attribute
@@ -39,7 +40,8 @@ namespace Pokemanz.Core
         Fire,
         Flying,
         Electric,
-        Normal
+        Normal,
+        Poison
     }
     
 }

--- a/src/Core/Pokemon.cs
+++ b/src/Core/Pokemon.cs
@@ -21,7 +21,6 @@ namespace Pokemanz.Core
         public int SpAttack { get; set; }
         public int SpDefense { get; set; }
         public int Speed { get; set; }
-        public int Ev { get; set; }
     }
 
     public class PokemonPropertyAttribute : Attribute

--- a/src/Core/compiler/resources/pokedex.txt
+++ b/src/Core/compiler/resources/pokedex.txt
@@ -1,11 +1,11 @@
 Id	Name	Type 1	Type 2	Level	Hp	Attack	Defense	SpAttack	SpDefense	Speed
-1	Bulbasuar	Grass		5	21	12	11	11	13	11
+1	Bulbasuar	Grass			45	49	49	65	65	45
 2										
 3										
-4	Charmander	Fire		5	20	12	10	10	11	13
+4	Charmander	Fire			20	12	10	10	11	13
 5										
 6										
-7	Squirtle	Water		5	20	12	13	9	12	10
+7	Squirtle	Water			20	12	13	9	12	10
 8										
 9										
 10										
@@ -14,13 +14,13 @@ Id	Name	Type 1	Type 2	Level	Hp	Attack	Defense	SpAttack	SpDefense	Speed
 13										
 14										
 15										
-16	Pidgey	Flying		5	20	12	10	9	10	12
+16	Pidgey	Flying			20	12	10	9	10	12
 17										
 18										
-19	Rattata	Normal		5	19	13	10	8	10	13
+19	Rattata	Normal			19	13	10	8	10	13
 20										
 21										
 22										
-23	Ekans			5	20	13	10	9	11	12
+23	Ekans	Poison			20	13	10	9	11	12
 24										
-25	Pikachu	Electric		5	20	13	10	9	11	15
+25	Pikachu	Electric			20	13	10	9	11	15


### PR DESCRIPTION
Single method to calculate a pokemon's new stats on level up. Core
formula is run, then extra arithmetic is added based on if the stat is
hp (unique formula), or one of the other stat types. A few variables to
not exist yet for this equation so it will not work.
